### PR TITLE
pip freeze requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 epydoc==3.0.1
 epyparse==0.2.5
 PyYAML==3.11
-sphinx-autoapi==0.1.1
 wheel==0.24.0
+sphinx==1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
-Sphinx==1.3.1
-https://bitbucket.org/readthedocs/sphinx-autoapi/get/master.zip
-https://github.com/snide/sphinx_rtd_theme/archive/master.zip
+epydoc==3.0.1
+epyparse==0.2.5
+PyYAML==3.11
+sphinx-autoapi==0.1.1
+wheel==0.24.0

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ try:
             'PyYAML',
             'epyparse',
             'epydoc',
+            'sphinx',
         ],
         test_suite='nose.collector',
         tests_require=['nose', 'mock'],
@@ -17,6 +18,7 @@ except ImportError:
             'PyYAML',
             'epyparse',
             'epydoc',
+            'sphinx'
         ],
     )
 


### PR DESCRIPTION
Some environments, like PyCharm, try to install `requirements.txt`
before they consider `setup.py`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/rtfd/sphinx-autoapi/1)
<!-- Reviewable:end -->
