### PR TITLE
Changes to support docfx

### DIFF
--- a/autoapi/extension.py
+++ b/autoapi/extension.py
@@ -48,12 +48,12 @@ def run_autoapi(app):
     if app.config.autoapi_file_patterns:
         file_patterns = app.config.autoapi_file_pattern
     else:
-        file_patterns = default_file_mapping[app.config.autoapi_type]
+        file_patterns = default_file_mapping.get(app.config.autoapi_type, [])
 
     if app.config.autoapi_ignore:
         ignore_patterns = app.config.autoapi_ignore
     else:
-        ignore_patterns = default_ignore_patterns[app.config.autoapi_type]
+        ignore_patterns = default_ignore_patterns.get(app.config.autoapi_type, [])
 
     app.info(bold('[AutoAPI] ') + darkgreen('Loading Data'))
     domain_obj.load(

--- a/autoapi/extension.py
+++ b/autoapi/extension.py
@@ -11,6 +11,7 @@ from sphinx.util.console import darkgreen, bold
 from sphinx.addnodes import toctree
 
 from .mappers import DotNetSphinxMapper, PythonSphinxMapper, GoSphinxMapper, JavaScriptSphinxMapper
+from .settings import default_file_mapping, default_ignore_patterns
 
 default_options = ['members', 'undoc-members', 'private-members', 'special-members']
 
@@ -41,13 +42,6 @@ def run_autoapi(app):
         'javascript': JavaScriptSphinxMapper,
     }
 
-    default_file_mapping = {
-        'python': ['*.py'],
-        'dotnet': ['project.json', '*.csproj', '*.vbproj'],
-        'go': ['*.go'],
-        'javascript': ['*.js'],
-    }
-
     domain = mapping[app.config.autoapi_type]
     domain_obj = domain(app, template_dir=app.config.autoapi_template_dir)
 
@@ -56,11 +50,16 @@ def run_autoapi(app):
     else:
         file_patterns = default_file_mapping[app.config.autoapi_type]
 
+    if app.config.autoapi_ignore:
+        ignore_patterns = app.config.autoapi_ignore
+    else:
+        ignore_patterns = default_ignore_patterns[app.config.autoapi_type]
+
     app.info(bold('[AutoAPI] ') + darkgreen('Loading Data'))
     domain_obj.load(
         patterns=file_patterns,
         dir=normalized_dir,
-        ignore=app.config.autoapi_ignore,
+        ignore=ignore_patterns,
     )
 
     app.info(bold('[AutoAPI] ') + darkgreen('Mapping Data'))
@@ -109,7 +108,7 @@ def setup(app):
     app.connect('doctree-read', doctree_read)
     app.add_config_value('autoapi_type', 'python', 'html')
     app.add_config_value('autoapi_root', 'autoapi', 'html')
-    app.add_config_value('autoapi_ignore', ['*migrations*'], 'html')
+    app.add_config_value('autoapi_ignore', [], 'html')
     app.add_config_value('autoapi_options', default_options, 'html')
     app.add_config_value('autoapi_file_patterns', None, 'html')
     app.add_config_value('autoapi_dir', 'autoapi', 'html')

--- a/autoapi/mappers/base.py
+++ b/autoapi/mappers/base.py
@@ -164,7 +164,7 @@ class SphinxMapperBase(object):
 
                     # Skip ignored files
                     for ignore_pattern in ignore:
-                        if fnmatch.fnmatch(filename, ignore_pattern):
+                        if fnmatch.fnmatch(os.path.join(root, filename), ignore_pattern):
                             self.app.info("Ignoring %s/%s" % (root, filename))
                             skip = True
 

--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -32,7 +32,8 @@ class DotNetSphinxMapper(SphinxMapperBase):
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     env=dict((key, os.environ[key])
-                              for key in ['PATH', 'DNX_PATH', 'HOME']))
+                             for key in ['PATH', 'DNX_PATH', 'HOME']
+                             if key in os.environ))
                 _, error_output = proc.communicate()
                 if error_output:
                     self.app.warn(error_output)

--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -1,6 +1,7 @@
+from collections import defaultdict
 import os
 import subprocess
-from collections import defaultdict
+import traceback
 
 import yaml
 from sphinx.util.osutil import ensuredir
@@ -33,7 +34,8 @@ class DotNetSphinxMapper(SphinxMapperBase):
                     stderr=subprocess.PIPE,
                     env=dict((key, os.environ[key])
                              for key in ['PATH', 'DNX_PATH', 'HOME']
-                             if key in os.environ))
+                             if key in os.environ),
+                )
                 _, error_output = proc.communicate()
                 if error_output:
                     self.app.warn(error_output)
@@ -210,9 +212,9 @@ class DotNetPythonMapper(PythonMapperBase):
         if syntax is not None:
             # Code example
             try:
-                self.example = syntax['content']['CSharp']
-            except KeyError:
-                pass
+                self.example = syntax['content']
+            except (KeyError, TypeError):
+                traceback.print_exc()
 
             self.parameters = []
             for param in syntax.get('parameters', []):

--- a/autoapi/settings.py
+++ b/autoapi/settings.py
@@ -8,3 +8,15 @@ import os
 
 SITE_ROOT = os.path.dirname(os.path.realpath(__file__))
 TEMPLATE_DIR = os.path.join(SITE_ROOT, 'templates')
+
+default_file_mapping = {
+    'python': ['*.py'],
+    'dotnet': ['project.json', '*.csproj', '*.vbproj'],
+    'go': ['*.go'],
+    'javascript': ['*.js'],
+}
+
+default_ignore_patterns = {
+    'dotnet': ['*toc.yml', '*index.yml'],
+    'python': ['*migrations*'],
+}

--- a/tests/dotnetexample/conf.py
+++ b/tests/dotnetexample/conf.py
@@ -18,6 +18,5 @@ htmlhelp_basename = 'dotnetexampledoc'
 extensions = ['autoapi.extension', 'sphinxcontrib.dotnetdomain']
 
 autoapi_type = 'dotnet'
-autoapi_dir = 'example/mvc/src/'
-autoapi_file_pattern = 'project.json'
-autoapi_ignore = ['toc.yml', 'index.yml']
+autoapi_dir = 'example/corefx/src'
+autoapi_ignore = ['*toc.yml', '*index.yml', '*tests*tests*']

--- a/tests/dotnetexample/conf.py
+++ b/tests/dotnetexample/conf.py
@@ -18,5 +18,5 @@ htmlhelp_basename = 'dotnetexampledoc'
 extensions = ['autoapi.extension', 'sphinxcontrib.dotnetdomain']
 
 autoapi_type = 'dotnet'
-autoapi_dir = 'example/corefx/src'
+autoapi_dir = 'example/mvc/src'
 autoapi_ignore = ['*toc.yml', '*index.yml', '*tests*tests*']


### PR DESCRIPTION
Note: This requires a patch on the docfx executable, the hashbang line is
missing, creating an execution failure

This makes the executed command docfx, instead of BuildMeta. It adds some error
checking and reporting to output as well.

This is a work in progress, the output format seems to have changed again.