### PR TITLE
Add ability for per-mapper cleanup tasks & general docfx cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs/autoapi
 readthedocs_build
 tests/*/_build
 tests/*/autoapi
+_api_

--- a/autoapi/mappers/base.py
+++ b/autoapi/mappers/base.py
@@ -7,9 +7,6 @@ from sphinx.util.console import darkgreen, bold
 from sphinx.util.osutil import ensuredir
 
 
-from ..settings import TEMPLATE_DIR
-
-
 class PythonMapperBase(object):
 
     '''
@@ -121,6 +118,7 @@ class SphinxMapperBase(object):
     '''
 
     def __init__(self, app, template_dir=None):
+        from ..settings import TEMPLATE_DIR
         self.app = app
 
         TEMPLATE_PATHS = [TEMPLATE_DIR]

--- a/autoapi/settings.py
+++ b/autoapi/settings.py
@@ -6,6 +6,8 @@ You shouldn't need to touch this.
 
 import os
 
+from .mappers import DotNetSphinxMapper, PythonSphinxMapper, GoSphinxMapper, JavaScriptSphinxMapper
+
 SITE_ROOT = os.path.dirname(os.path.realpath(__file__))
 TEMPLATE_DIR = os.path.join(SITE_ROOT, 'templates')
 
@@ -19,4 +21,11 @@ default_file_mapping = {
 default_ignore_patterns = {
     'dotnet': ['*toc.yml', '*index.yml'],
     'python': ['*migrations*'],
+}
+
+default_backend_mapping = {
+    'python': PythonSphinxMapper,
+    'dotnet': DotNetSphinxMapper,
+    'go': GoSphinxMapper,
+    'javascript': JavaScriptSphinxMapper,
 }

--- a/tests/dotnetexample/README.md
+++ b/tests/dotnetexample/README.md
@@ -1,10 +1,12 @@
 ## .Net example
 
-This assumes that you have a ``MSBuild`` executable on your `PATH`.
+This assumes that you have a ``docfx`` executable on your `PATH`.
+It also depends on the sphinxcontrib-dotnet domain: https://github.com/rtfd/sphinxcontrib-dotnetdomain
 
-Currently this is setup to build the full ASP.NET MVC repo.
-It is a great testcase,
-but is probably a bit large for production tests.
+Currently this is setup to build the Indentity repo from ASP.Net
 
 We don't have the checkout in the repo,
 but there's a ``clone.sh`` in the ``example`` directory which will clone it properly.
+
+
+Then you should simply be able to run ``make html`` in this directory.

--- a/tests/dotnetexample/README.md
+++ b/tests/dotnetexample/README.md
@@ -1,4 +1,4 @@
-## .Net example
+## .NET example
 
 This assumes that you have a ``docfx`` executable on your `PATH`.
 It also depends on the sphinxcontrib-dotnet domain: https://github.com/rtfd/sphinxcontrib-dotnetdomain

--- a/tests/dotnetexample/conf.py
+++ b/tests/dotnetexample/conf.py
@@ -19,3 +19,10 @@ extensions = ['autoapi.extension', 'sphinxcontrib.dotnetdomain']
 autoapi_type = 'dotnet'
 autoapi_dir = 'example/Identity/src/'
 autoapi_keep_files = True
+
+import os
+
+SITE_ROOT = os.path.dirname(os.path.realpath(__file__))
+DIR = os.path.join(SITE_ROOT, autoapi_dir)
+if not os.path.exists(DIR):
+    os.system('git clone https://github.com/aspnet/Identity %s' % os.path.join(SITE_ROOT, 'example/Identity'))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -77,8 +77,13 @@ class DotNetTests(LanguageIntegrationTests):
         data = self.read_file(path='inmem')
         self.paths['inmem'] = data
 
+    @staticmethod
+    def _dotnet_finished(app, exception):
+        pass
+
     @patch('autoapi.mappers.dotnet.DotNetSphinxMapper.load', _dotnet_load)
     @patch('autoapi.mappers.dotnet.DotNetSphinxMapper.read_file', _dotnet_read)
+    @patch('autoapi.mappers.dotnet.DotNetSphinxMapper.build_finished', _dotnet_finished)
     def test_integration(self):
         self._run_test(
             'dotnetexample',


### PR DESCRIPTION
This fixes a number of small issues with the configs,
and adds per-mapper cleanup.

This allows the Dotnet mapper to clean up the `_api` directory
and other output that is Mapper specific.

Also concat's all of the files in the call to docfx, which was the main bug with children not appearing correctly in the YAML output. 

I believe these were the last 2 large issues related to local .Net building. 