### PR TITLE
Add Windows builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,14 +2,9 @@ build: false
 environment:
   matrix:
     - PYTHON: "C:/Python27"
-    - PYTHON: "C:/Python34"
-init:
-  - "ECHO %PYTHON%"
-  - ps: "ls C:/Python*"
 install:
   - ps: (new-object net.webclient).DownloadFile('https://raw.github.com/pypa/pip/master/contrib/get-pip.py', 'C:/get-pip.py')
   - "%PYTHON%/python.exe C:/get-pip.py"
-  - "%PYTHON%/Scripts/pip.exe install -e ."
 test_script:
   - "%PYTHON%/Scripts/pip.exe --version"
   - "%PYTHON%/Scripts/pip.exe install tox"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,5 +12,5 @@ install:
   - "%PYTHON%/Scripts/pip.exe install -e ."
 test_script:
   - "%PYTHON%/Scripts/pip.exe --version"
-  - "%PYTHON%/Scripts/http.exe --debug"
-  - "%PYTHON%/python.exe setup.py test"
+  - "%PYTHON%/Scripts/pip.exe install tox"
+  - "%PYTHON%/Scripts/tox.exe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,16 @@
+build: false
+environment:
+  matrix:
+    - PYTHON: "C:/Python27"
+    - PYTHON: "C:/Python34"
+init:
+  - "ECHO %PYTHON%"
+  - ps: "ls C:/Python*"
+install:
+  - ps: (new-object net.webclient).DownloadFile('https://raw.github.com/pypa/pip/master/contrib/get-pip.py', 'C:/get-pip.py')
+  - "%PYTHON%/python.exe C:/get-pip.py"
+  - "%PYTHON%/Scripts/pip.exe install -e ."
+test_script:
+  - "%PYTHON%/Scripts/pip.exe --version"
+  - "%PYTHON%/Scripts/http.exe --debug"
+  - "%PYTHON%/python.exe setup.py test"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,4 +8,4 @@ install:
 test_script:
   - "%PYTHON%/Scripts/pip.exe --version"
   - "%PYTHON%/Scripts/pip.exe install tox"
-  - "%PYTHON%/Scripts/tox.exe"
+  - "%PYTHON%/Scripts/tox.exe -e py27"

--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -36,7 +36,7 @@ class DotNetSphinxMapper(SphinxMapperBase):
             all_files.add(_file)
         if all_files:
             try:
-                command = ['docfx', 'metadata', '--raw', '--force']
+                command = ['bash', 'docfx', 'metadata', '--raw', '--force']
                 command.extend(all_files)
                 proc = subprocess.Popen(
                     command,

--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -180,7 +180,7 @@ class DotNetSphinxMapper(SphinxMapperBase):
                 filename = obj.name.split('(')[0]
             except IndexError:
                 filename = id
-            filename = filename.replace('#', '-')
+            filename = filename.replace('#', '-').replace('<', '-').replace('>', '')
             detail_dir = os.path.join(root, *filename.split('.'))
             ensuredir(detail_dir)
             path = os.path.join(detail_dir, '%s%s' % ('index', source_suffix))

--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -184,12 +184,12 @@ class DotNetSphinxMapper(SphinxMapperBase):
             detail_dir = os.path.join(root, *filename.split('.'))
             ensuredir(detail_dir)
             path = os.path.join(detail_dir, '%s%s' % ('index', source_suffix))
-            with open(path, 'wb+') as detail_file:
+            with open(path, 'wb') as detail_file:
                 detail_file.write(rst.encode('utf-8'))
 
         # Render Top Index
         top_level_index = os.path.join(root, 'index.rst')
-        with open(top_level_index, 'wb+') as top_level_file:
+        with open(top_level_index, 'wb') as top_level_file:
             content = self.jinja_env.get_template('index.rst')
             top_level_file.write(content.render(pages=self.namespaces.values()).encode('utf-8'))
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -89,7 +89,7 @@ class DotNetTests(LanguageIntegrationTests):
     def test_integration(self):
         self._run_test(
             'dotnetexample',
-            '_build/text/autoapi/Microsoft/AspNet/JsonPatch/Adapters/IObjectAdapter<TModel>/index.txt',
+            '_build/text/autoapi/Microsoft/AspNet/JsonPatch/Adapters/IObjectAdapter-TModel/index.txt',
             'Defines the operations that can be performed on a JSON patch document.'
         )
 


### PR DESCRIPTION
This adds appveyor support, and builds for Windows. Currently they are failing on Python 3 because of an error in the Babel library. 