### PR TITLE
Stub out XML parsing

### DIFF
--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -219,7 +219,7 @@ class DotNetPythonMapper(PythonMapperBase):
 
         # Optional
         self.fullname = obj.get('fullName')
-        self.summary = obj.get('summary', '')
+        self.summary = self.parse_xml(obj.get('summary', ''))
         self.parameters = []
         self.items = obj.get('items', [])
         self.children_strings = obj.get('children', [])
@@ -243,7 +243,7 @@ class DotNetPythonMapper(PythonMapperBase):
                     self.parameters.append({
                         'name': param.get('id'),
                         'type': param.get('type'),
-                        'desc': param.get('description', '')
+                        'desc': self.parse_xml(param.get('description', ''))
                     })
 
             self.returns = syntax.get('return', None)
@@ -252,6 +252,7 @@ class DotNetPythonMapper(PythonMapperBase):
         # TODO Support more than just a class type here, should support enum/etc
         self.inheritance = [DotNetClass({'uid': name, 'name': name})
                             for name in obj.get('inheritance', [])]
+
 
     def __str__(self):
         return '<{cls} {id}>'.format(cls=self.__class__.__name__,
@@ -324,6 +325,14 @@ class DotNetPythonMapper(PythonMapperBase):
     def ref_short_name(self):
         '''Same as above, return the truncated name instead'''
         return self.ref_name.split('.')[-1]
+
+    def parse_xml(self, text):
+        """
+        Parse XML content for references and other syntax.
+        Ref: https://msdn.microsoft.com/en-us/library/5ast78ax.aspx
+        """
+        # Don't do this for now
+        return text
 
 
 class DotNetNamespace(DotNetPythonMapper):

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -90,3 +90,25 @@ class DomainTests(unittest.TestCase):
                 self.assertEqual(objs['Foo.Bar'].name, 'Foo.Bar')
                 self.assertEqual(objs['Foo.Bar2'].id, 'Foo.Bar2')
                 self.assertEqual(objs['Foo.Bar2'].name, 'Foo.Bar2')
+
+    def test_xml_parse(self):
+        '''XML doc comment parsing'''
+        ret = dotnet.DotNetPythonMapper.transform_doc_comments(
+            'This is an example comment <see cref="FOO" />')
+        self.assertEqual(ret, 'This is an example comment :dn:ref:`FOO`')
+
+        ret = dotnet.DotNetPythonMapper.transform_doc_comments(
+            'This is an example comment <see cref="FOO">inner foo</see>')
+        self.assertEqual(ret, 'This is an example comment :dn:ref:`FOO`')
+
+        ret = dotnet.DotNetPythonMapper.transform_doc_comments(
+            'Test <see cref="FOO" /> and <see cref="BAR">Blah</see>')
+        self.assertEqual(ret, 'Test :dn:ref:`FOO` and :dn:ref:`BAR`')
+
+        ret = dotnet.DotNetPythonMapper.transform_doc_comments(
+            'This is an example comment <paramref name="FOO" />')
+        self.assertEqual(ret, 'This is an example comment ``FOO``')
+
+        ret = dotnet.DotNetPythonMapper.transform_doc_comments(
+            'This is an example comment <typeparamref name="FOO" />')
+        self.assertEqual(ret, 'This is an example comment ``FOO``')

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -98,12 +98,16 @@ class DomainTests(unittest.TestCase):
         self.assertEqual(ret, 'This is an example comment :dn:ref:`FOO`')
 
         ret = dotnet.DotNetPythonMapper.transform_doc_comments(
-            'This is an example comment <see cref="FOO">inner foo</see>')
-        self.assertEqual(ret, 'This is an example comment :dn:ref:`FOO`')
+            'This is an example comment <see cref="!:FOO" />')
+        self.assertEqual(ret, 'This is an example comment FOO')
 
         ret = dotnet.DotNetPythonMapper.transform_doc_comments(
-            'Test <see cref="FOO" /> and <see cref="BAR">Blah</see>')
-        self.assertEqual(ret, 'Test :dn:ref:`FOO` and :dn:ref:`BAR`')
+            'This is an example comment <see cref="N:FOO">inner foo</see>')
+        self.assertEqual(ret, 'This is an example comment :dn:ns:`FOO`')
+
+        ret = dotnet.DotNetPythonMapper.transform_doc_comments(
+            'Test <see cref="P:FOO" /> and <see cref="E:BAR">Blah</see>')
+        self.assertEqual(ret, 'Test :dn:prop:`FOO` and :dn:event:`BAR`')
 
         ret = dotnet.DotNetPythonMapper.transform_doc_comments(
             'This is an example comment <paramref name="FOO" />')


### PR DESCRIPTION
Adds XML doc comment parsing on description, parameter, and return fields. It handles the following tags:

* `see` and `seealso` - replaces with a reference link
* `paramref` and `typeparamref` - just replaces with bold text as we can't reference parameters