### PR TITLE
Use more proper slugging on filenames for object

### DIFF
--- a/autoapi/mappers/base.py
+++ b/autoapi/mappers/base.py
@@ -1,7 +1,9 @@
+import re
 import os
 import fnmatch
 from collections import OrderedDict
 
+import unidecode
 from jinja2 import Environment, FileSystemLoader, TemplateNotFound
 from sphinx.util.console import darkgreen, bold
 from sphinx.util.osutil import ensuredir
@@ -94,6 +96,27 @@ class PythonMapperBase(object):
     def short_name(self):
         '''Shorten name property'''
         return self.name.split('.')[-1]
+
+    @property
+    def pathname(self):
+        '''Sluggified path for filenames
+
+        Slugs to a filename using the follow steps
+
+        * Decode unicode to approximate ascii
+        * Remove existing hypens
+        * Substitute hyphens for non-word characters
+        * Break up the string as paths
+        '''
+        slug = self.name
+        try:
+            slug = self.name.split('(')[0]
+        except IndexError:
+            pass
+        slug = unidecode.unidecode(slug)
+        slug = slug.replace('-', '')
+        slug = re.sub(r'[^\w\.]+', '-', slug).strip('-')
+        return os.path.join(*slug.split('.'))
 
     @property
     def ref_type(self):

--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -179,12 +179,7 @@ class DotNetSphinxMapper(SphinxMapperBase):
             if not rst:
                 continue
 
-            try:
-                filename = obj.name.split('(')[0]
-            except IndexError:
-                filename = id
-            filename = filename.replace('#', '-')
-            detail_dir = os.path.join(root, *filename.split('.'))
+            detail_dir = os.path.join(root, obj.pathname)
             ensuredir(detail_dir)
             path = os.path.join(detail_dir, '%s%s' % ('index', source_suffix))
             with open(path, 'wb') as detail_file:

--- a/autoapi/templates/dotnet/base_list.rst
+++ b/autoapi/templates/dotnet/base_list.rst
@@ -15,7 +15,7 @@
 
    {% for item in obj.children|sort %}
    {% if item.type != 'namespace' %}
-   /autoapi/{{ item.name.split('.')|join('/') }}/index
+   /autoapi/{{ item.pathname }}/index
    {% endif %}
    {% endfor %}
 
@@ -30,7 +30,7 @@
 
    {% for item in obj.references|sort %}
    {% if item.type != 'namespace' %}
-   /autoapi/{{ item.name.split('.')|join('/') }}/index
+   /autoapi/{{ item.pathname }}/index
    {% endif %}
    {% endfor %}
 

--- a/autoapi/templates/javascript/module.rst
+++ b/autoapi/templates/javascript/module.rst
@@ -9,7 +9,7 @@
    :maxdepth: 4
 
    {% for item in obj.children|sort %}
-   /autoapi/{{ item.id.split('.')|join('/') }}/index
+   /autoapi/{{ item.pathname }}/index
    {%- endfor %}
 
 {% endif %}

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ try:
             'sphinx',
             'sphinxcontrib-golangdomain',
             'sphinxcontrib-dotnetdomain',
+            'unidecode',
         ],
         test_suite='nose.collector',
         tests_require=['nose', 'mock'],
@@ -23,6 +24,7 @@ except ImportError:
             'sphinx'
             'sphinxcontrib-golangdomain',
             'sphinxcontrib-dotnetdomain',
+            'unidecode',
         ],
     )
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -2,6 +2,7 @@
 
 '''Test .NET autoapi objects'''
 
+import os
 import unittest
 
 from autoapi.mappers import dotnet
@@ -100,14 +101,14 @@ class NamespaceTests(unittest.TestCase):
     def test_filename(self):
         '''Object file name'''
         cls = dotnet.DotNetClass({'id': 'Foo.Bar.Widget'})
-        self.assertEqual(cls.pathname, 'Foo/Bar/Widget')
+        self.assertEqual(cls.pathname, os.path.join('Foo', 'Bar', 'Widget'))
         cls = dotnet.DotNetClass({'id': 'Foo.Bar.Widget<T>'})
-        self.assertEqual(cls.pathname, 'Foo/Bar/Widget-T')
+        self.assertEqual(cls.pathname, os.path.join('Foo', 'Bar', 'Widget-T'))
         cls = dotnet.DotNetClass({'id': 'Foo.Bar.Widget<T>(TFoo)'})
-        self.assertEqual(cls.pathname, 'Foo/Bar/Widget-T')
+        self.assertEqual(cls.pathname, os.path.join('Foo', 'Bar', 'Widget-T'))
         cls = dotnet.DotNetClass({'id': 'Foo.Foo-Bar.Widget<T>(TFoo)'})
-        self.assertEqual(cls.pathname, 'Foo/FooBar/Widget-T')
+        self.assertEqual(cls.pathname, os.path.join('Foo', 'FooBar', 'Widget-T'))
         cls = dotnet.DotNetClass({'id': u'Foo.Bär'})
-        self.assertEqual(cls.pathname, u'Foo/Bar')
+        self.assertEqual(cls.pathname, os.path.join('Foo', 'Bar'))
         cls = dotnet.DotNetClass({'id': u'Ащщ.юИфк'})
-        self.assertEqual(cls.pathname, u'Ashchshch/iuIfk')
+        self.assertEqual(cls.pathname, os.path.join('Ashchshch', 'iuIfk'))

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,3 +1,5 @@
+# coding=utf8
+
 '''Test .NET autoapi objects'''
 
 import unittest
@@ -94,3 +96,18 @@ class NamespaceTests(unittest.TestCase):
         cls = dotnet.DotNetClass(dict(id='Foo',
                                       type='class'))
         self.assertIsNone(cls.namespace)
+
+    def test_filename(self):
+        '''Object file name'''
+        cls = dotnet.DotNetClass({'id': 'Foo.Bar.Widget'})
+        self.assertEqual(cls.pathname, 'Foo/Bar/Widget')
+        cls = dotnet.DotNetClass({'id': 'Foo.Bar.Widget<T>'})
+        self.assertEqual(cls.pathname, 'Foo/Bar/Widget-T')
+        cls = dotnet.DotNetClass({'id': 'Foo.Bar.Widget<T>(TFoo)'})
+        self.assertEqual(cls.pathname, 'Foo/Bar/Widget-T')
+        cls = dotnet.DotNetClass({'id': 'Foo.Foo-Bar.Widget<T>(TFoo)'})
+        self.assertEqual(cls.pathname, 'Foo/FooBar/Widget-T')
+        cls = dotnet.DotNetClass({'id': u'Foo.Bär'})
+        self.assertEqual(cls.pathname, u'Foo/Bar')
+        cls = dotnet.DotNetClass({'id': u'Ащщ.юИфк'})
+        self.assertEqual(cls.pathname, u'Ashchshch/iuIfk')


### PR DESCRIPTION
This resolves some issues with special characters in paths on Windows based
systems. It replaces special characters and unicode characters to ensure paths
are predictable.

Fixes #21 