### PR TITLE
Fixes necessary for running on Windows

### DIFF
--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -1,5 +1,6 @@
 import re
 import os
+import platform
 import subprocess
 import traceback
 import shutil
@@ -12,6 +13,10 @@ from sphinx.errors import ExtensionError
 
 from .base import PythonMapperBase, SphinxMapperBase
 
+
+DOCFX_COMMAND = 'docfx'
+if platform.system() == 'Windows':
+    DOCFX_COMMAND = 'docfx.cmd'
 
 # Doc comment patterns
 DOC_COMMENT_PATTERN = r'''
@@ -68,7 +73,7 @@ class DotNetSphinxMapper(SphinxMapperBase):
             all_files.add(_file)
         if all_files:
             try:
-                command = ['docfx', 'metadata', '--raw', '--force']
+                command = [DOCFX_COMMAND, 'metadata', '--raw', '--force']
                 command.extend(all_files)
                 proc = subprocess.Popen(
                     ' '.join(command),

--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -79,7 +79,6 @@ class DotNetSphinxMapper(SphinxMapperBase):
                     ' '.join(command),
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
-                    shell=True,
                     env=dict((key, os.environ[key])
                              for key in ['PATH', 'HOME']
                              if key in os.environ),

--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -1,6 +1,5 @@
 import re
 import os
-import platform
 import subprocess
 import traceback
 import shutil
@@ -13,10 +12,6 @@ from sphinx.errors import ExtensionError
 
 from .base import PythonMapperBase, SphinxMapperBase
 
-
-DOCFX_COMMAND = 'docfx'
-if platform.system() == 'Windows':
-    DOCFX_COMMAND = 'docfx.cmd'
 
 # Doc comment patterns
 DOC_COMMENT_PATTERN = r'''
@@ -73,14 +68,16 @@ class DotNetSphinxMapper(SphinxMapperBase):
             all_files.add(_file)
         if all_files:
             try:
-                command = [DOCFX_COMMAND, 'metadata', '--raw', '--force']
+                command = ['docfx', 'metadata', '--raw', '--force']
                 command.extend(all_files)
                 proc = subprocess.Popen(
                     ' '.join(command),
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
+                    shell=True,
                     env=dict((key, os.environ[key])
-                             for key in ['PATH', 'HOME']
+                             for key in ['PATH', 'HOME', 'SYSTEMROOT',
+                                         'USERPROFILE', 'WINDIR']
                              if key in os.environ),
                 )
                 _, error_output = proc.communicate()


### PR DESCRIPTION
Previously, we were expecting the command would always be `docfx`, which on a windows box, the command is `docfx.cmd`. This configures the command based on system and also removes a problematic subprocess `shell=True` argument.

The `shell=True` argument wouldn't be needed, except the `docfx` tool on linux is missing it's shebang line and this proxy command fails if subprocess isn't using shell emulation.

This will be blocking until we have a fix for removing `shell=True` for unix systems.