### PR TITLE
References and escaping issues with transformed XML content

### DIFF
--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -35,12 +35,12 @@ DOC_COMMENT_PARAM_PATTERN = re.compile(
 # Comment member identities
 # From: https://msdn.microsoft.com/en-us/library/vstudio/fsbx0t7x(v=VS.100).aspx
 DOC_COMMENT_IDENTITIES = {
-    'N': 'ns',
-    'T': 'ref',  # can be any type (class, delegate, enum, etc), so use ref
-    'F': 'field',
-    'P': 'prop',
-    'M': 'meth',
-    'E': 'event',
+    'N': 'dn:ns',
+    'T': 'any',  # can be any type (class, delegate, enum, etc), so use any
+    'F': 'dn:field',
+    'P': 'dn:prop',
+    'M': 'dn:meth',
+    'E': 'dn:event',
 }
 
 
@@ -378,19 +378,19 @@ class DotNetPythonMapper(PythonMapperBase):
                        .replace('<', '\<')
                        .replace('`', '\`'))
 
-                reftype = 'ref'
+                reftype = 'any'
                 replacement = ''
                 # Given the pattern of `\w:\w+`, inspect first letter of
                 # reference for identity type
                 if ref[1] == ':' and ref[0] in DOC_COMMENT_IDENTITIES:
                     reftype = DOC_COMMENT_IDENTITIES[ref[:1]]
                     ref = ref[2:]
-                    replacement = ':dn:{reftype}:`{ref}`'.format(
+                    replacement = ':{reftype}:`{ref}`'.format(
                         reftype=reftype, ref=ref)
                 elif ref[:2] == '!:':
                     replacement = ref[2:]
                 else:
-                    replacement = ':dn:ref:`{ref}`'.format(ref=ref)
+                    replacement = ':any:`{ref}`'.format(ref=ref)
 
                 # Escape following text
                 text_end = text[found.end():]

--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -374,7 +374,10 @@ class DotNetPythonMapper(PythonMapperBase):
                 found = DOC_COMMENT_SEE_PATTERN.search(text)
                 if found is None:
                     break
-                ref = found.group('attr_value')
+                ref = (found.group('attr_value')
+                       .replace('<', '\<')
+                       .replace('`', '\`'))
+
                 reftype = 'ref'
                 replacement = ''
                 # Given the pattern of `\w:\w+`, inspect first letter of
@@ -389,9 +392,13 @@ class DotNetPythonMapper(PythonMapperBase):
                 else:
                     replacement = ':dn:ref:`{ref}`'.format(ref=ref)
 
-                text = ''.join([text[:found.start()],
-                                replacement,
-                                text[found.end():]])
+                # Escape following text
+                text_end = text[found.end():]
+                text_start = text[:found.start()]
+                text_end = re.sub(r'^(\S)', r'\\\1', text_end)
+                text_start = re.sub(r'(\S)$', r'\1 ', text_start)
+
+                text = ''.join([text_start, replacement, text_end])
             text = DOC_COMMENT_PARAM_PATTERN.sub(
                 '``\g<attr_value>``', text)
         except TypeError:

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -95,7 +95,7 @@ class DomainTests(unittest.TestCase):
         '''XML doc comment parsing'''
         ret = dotnet.DotNetPythonMapper.transform_doc_comments(
             'This is an example comment <see cref="FOO" />')
-        self.assertEqual(ret, 'This is an example comment :dn:ref:`FOO`')
+        self.assertEqual(ret, 'This is an example comment :any:`FOO`')
 
         ret = dotnet.DotNetPythonMapper.transform_doc_comments(
             'This is an example comment <see cref="!:FOO" />')
@@ -121,7 +121,7 @@ class DomainTests(unittest.TestCase):
         """XML transform escaping"""
         ret = dotnet.DotNetPythonMapper.transform_doc_comments(
             'Foo <see cref="Foo`1" /> Bar')
-        self.assertEqual(ret, 'Foo :dn:ref:`Foo\\`1` Bar')
+        self.assertEqual(ret, 'Foo :any:`Foo\\`1` Bar')
 
         ret = dotnet.DotNetPythonMapper.transform_doc_comments(
             'No space before<see cref="M:Foo`1" />or after')

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -121,7 +121,7 @@ class DomainTests(unittest.TestCase):
         """XML transform escaping"""
         ret = dotnet.DotNetPythonMapper.transform_doc_comments(
             'Foo <see cref="Foo`1" /> Bar')
-        self.assertEqual(ret, 'Foo :dn:ref:`Foo\\`1`')
+        self.assertEqual(ret, 'Foo :dn:ref:`Foo\\`1` Bar')
 
         ret = dotnet.DotNetPythonMapper.transform_doc_comments(
             'No space before<see cref="M:Foo`1" />or after')

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -116,3 +116,13 @@ class DomainTests(unittest.TestCase):
         ret = dotnet.DotNetPythonMapper.transform_doc_comments(
             'This is an example comment <typeparamref name="FOO" />')
         self.assertEqual(ret, 'This is an example comment ``FOO``')
+
+    def test_xml_transform_escape(self):
+        """XML transform escaping"""
+        ret = dotnet.DotNetPythonMapper.transform_doc_comments(
+            'Foo <see cref="Foo`1" /> Bar')
+        self.assertEqual(ret, 'Foo :dn:ref:`Foo\\`1`')
+
+        ret = dotnet.DotNetPythonMapper.transform_doc_comments(
+            'No space before<see cref="M:Foo`1" />or after')
+        self.assertEqual(ret, 'No space before :dn:meth:`Foo\\`1`\\or after')

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -5,10 +5,13 @@
 import os
 import unittest
 
+from jinja2 import Environment, FileSystemLoader
+
 from autoapi.mappers import dotnet
+from autoapi.settings import TEMPLATE_DIR
 
 
-class NamespaceTests(unittest.TestCase):
+class DotNetTests(unittest.TestCase):
 
     def test_type(self):
         '''Test types of some of the objects'''
@@ -112,3 +115,16 @@ class NamespaceTests(unittest.TestCase):
         self.assertEqual(cls.pathname, os.path.join('Foo', 'Bar'))
         cls = dotnet.DotNetClass({'id': u'Ащщ.юИфк'})
         self.assertEqual(cls.pathname, os.path.join('Ashchshch', 'iuIfk'))
+
+    def test_rendered_class_escaping(self):
+        """Rendered class escaping"""
+        jinja_env = Environment(
+            loader=FileSystemLoader([TEMPLATE_DIR]),
+        )
+        cls = dotnet.DotNetClass(
+            {
+                'id': 'Foo.Bar`1',
+                'inheritance': ['Foo.Baz`1'],
+            },
+            jinja_env=jinja_env)
+        self.assertIn('* :dn:cls:`Foo.Baz\\`1`\n', cls.render())


### PR DESCRIPTION
Fixes some missed transforms on XML data. Also, a pass at reducing number of warnings due to missing anchor references. A proper fix requires establishing a generic lookup reference in the domain.

Fixes #38