### PR TITLE
Fix template path issues on windows

### DIFF
--- a/autoapi/extension.py
+++ b/autoapi/extension.py
@@ -12,6 +12,7 @@ from sphinx.addnodes import toctree
 from sphinx.errors import ExtensionError
 
 from .backends import default_file_mapping, default_ignore_patterns, default_backend_mapping
+from .settings import URL_ROOT
 
 default_options = ['members', 'undoc-members', 'private-members', 'special-members']
 
@@ -48,7 +49,8 @@ def run_autoapi(app):
     app.env.autoapi_data = []
 
     domain = default_backend_mapping[app.config.autoapi_type]
-    domain_obj = domain(app, template_dir=app.config.autoapi_template_dir)
+    domain_obj = domain(app, template_dir=app.config.autoapi_template_dir,
+                        url_root=app.config.autoapi_url_root)
 
     if app.config.autoapi_file_patterns:
         file_patterns = app.config.autoapi_file_patterns
@@ -124,4 +126,5 @@ def setup(app):
     app.add_config_value('autoapi_keep_files', False, 'html')
     app.add_config_value('autoapi_add_toctree_entry', True, 'html')
     app.add_config_value('autoapi_template_dir', [], 'html')
+    app.add_config_value('autoapi_url_root', URL_ROOT, 'html')
     app.add_stylesheet('autoapi.css')

--- a/autoapi/extension.py
+++ b/autoapi/extension.py
@@ -12,7 +12,7 @@ from sphinx.addnodes import toctree
 from sphinx.errors import ExtensionError
 
 from .backends import default_file_mapping, default_ignore_patterns, default_backend_mapping
-from .settings import URL_ROOT
+from .settings import API_ROOT
 
 default_options = ['members', 'undoc-members', 'private-members', 'special-members']
 
@@ -45,12 +45,13 @@ def run_autoapi(app):
             )
 
     normalized_root = os.path.normpath(os.path.join(app.confdir, app.config.autoapi_root))
+    url_root = os.path.join('/', app.config.autoapi_root)
 
     app.env.autoapi_data = []
 
     domain = default_backend_mapping[app.config.autoapi_type]
     domain_obj = domain(app, template_dir=app.config.autoapi_template_dir,
-                        url_root=app.config.autoapi_url_root)
+                        url_root=url_root)
 
     if app.config.autoapi_file_patterns:
         file_patterns = app.config.autoapi_file_patterns
@@ -118,7 +119,7 @@ def setup(app):
     app.connect('build-finished', build_finished)
     app.connect('doctree-read', doctree_read)
     app.add_config_value('autoapi_type', 'python', 'html')
-    app.add_config_value('autoapi_root', 'autoapi', 'html')
+    app.add_config_value('autoapi_root', API_ROOT, 'html')
     app.add_config_value('autoapi_ignore', [], 'html')
     app.add_config_value('autoapi_options', default_options, 'html')
     app.add_config_value('autoapi_file_patterns', None, 'html')
@@ -126,5 +127,4 @@ def setup(app):
     app.add_config_value('autoapi_keep_files', False, 'html')
     app.add_config_value('autoapi_add_toctree_entry', True, 'html')
     app.add_config_value('autoapi_template_dir', [], 'html')
-    app.add_config_value('autoapi_url_root', URL_ROOT, 'html')
     app.add_stylesheet('autoapi.css')

--- a/autoapi/mappers/base.py
+++ b/autoapi/mappers/base.py
@@ -125,6 +125,18 @@ class PythonMapperBase(object):
         return os.path.join(*slug.split('.'))
 
     @property
+    def include_path(self):
+        """Return 'absolute' path without regarding OS path separator
+
+        This is used in ``toctree`` directives, as Sphinx always expects Unix
+        path separators
+        """
+        parts = [self.url_root]
+        parts.extend(self.pathname.split(os.path.sep))
+        parts.append('index')
+        return '/'.join(parts)
+
+    @property
     def ref_type(self):
         return self.type
 

--- a/autoapi/mappers/base.py
+++ b/autoapi/mappers/base.py
@@ -8,6 +8,8 @@ from jinja2 import Environment, FileSystemLoader, TemplateNotFound
 from sphinx.util.console import darkgreen, bold
 from sphinx.util.osutil import ensuredir
 
+from ..settings import URL_ROOT
+
 
 class PythonMapperBase(object):
 
@@ -22,6 +24,7 @@ class PythonMapperBase(object):
 
     :param obj: JSON object representing this object
     :param jinja_env: A template environment for rendering this object
+    :param url_root: API URL root prefix
 
     Required attributes:
 
@@ -44,11 +47,14 @@ class PythonMapperBase(object):
     # Create a page in the output for this object.
     top_level_object = False
 
-    def __init__(self, obj, options=None, jinja_env=None):
+    def __init__(self, obj, options=None, jinja_env=None, url_root=None):
         self.obj = obj
         self.options = options
         if jinja_env:
             self.jinja_env = jinja_env
+        if url_root is None:
+            url_root = URL_ROOT
+        self.url_root = url_root
 
     def render(self, **kwargs):
         ctx = {}
@@ -141,7 +147,7 @@ class SphinxMapperBase(object):
 
     '''
 
-    def __init__(self, app, template_dir=None):
+    def __init__(self, app, template_dir=None, url_root=None):
         from ..settings import TEMPLATE_DIR
         self.app = app
 
@@ -157,6 +163,8 @@ class SphinxMapperBase(object):
             # trim_blocks=True,
             # lstrip_blocks=True,
         )
+
+        self.url_root = url_root
 
         # Mapping of {filepath -> raw data}
         self.paths = OrderedDict()

--- a/autoapi/mappers/base.py
+++ b/autoapi/mappers/base.py
@@ -8,7 +8,7 @@ from jinja2 import Environment, FileSystemLoader, TemplateNotFound
 from sphinx.util.console import darkgreen, bold
 from sphinx.util.osutil import ensuredir
 
-from ..settings import URL_ROOT
+from ..settings import API_ROOT
 
 
 class PythonMapperBase(object):
@@ -53,7 +53,7 @@ class PythonMapperBase(object):
         if jinja_env:
             self.jinja_env = jinja_env
         if url_root is None:
-            url_root = URL_ROOT
+            url_root = os.path.join('/', API_ROOT)
         self.url_root = url_root
 
     def render(self, **kwargs):

--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -356,8 +356,9 @@ class DotNetPythonMapper(PythonMapperBase):
         return self.ref_name.split('.')[-1]
 
     @property
-    def abs_path(self):
-        return os.path.join(os.path.sep, 'autoapi', self.pathname, 'index')
+    def include_path(self):
+        """Return 'absolute' path without regarding OS path separator"""
+        return '/'.join(['/autoapi', self.pathname, 'index'])
 
     @staticmethod
     def transform_doc_comments(text):

--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -358,7 +358,10 @@ class DotNetPythonMapper(PythonMapperBase):
     @property
     def include_path(self):
         """Return 'absolute' path without regarding OS path separator"""
-        return '/'.join(['/autoapi', self.pathname, 'index'])
+        parts = ['/autoapi']
+        parts.extend(self.pathname.split(os.path.sep))
+        parts.append('index')
+        return '/'.join(parts)
 
     @staticmethod
     def transform_doc_comments(text):

--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -355,6 +355,10 @@ class DotNetPythonMapper(PythonMapperBase):
         '''Same as above, return the truncated name instead'''
         return self.ref_name.split('.')[-1]
 
+    @property
+    def abs_path(self):
+        return os.path.join(os.path.sep, 'autoapi', self.pathname, 'index')
+
     @staticmethod
     def transform_doc_comments(text):
         """

--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -356,18 +356,6 @@ class DotNetPythonMapper(PythonMapperBase):
         '''Same as above, return the truncated name instead'''
         return self.ref_name.split('.')[-1]
 
-    @property
-    def include_path(self):
-        """Return 'absolute' path without regarding OS path separator
-
-        This is used in ``toctree`` directives, as Sphinx always expects Unix
-        path separators
-        """
-        parts = [self.url_root]
-        parts.extend(self.pathname.split(os.path.sep))
-        parts.append('index')
-        return '/'.join(parts)
-
     @staticmethod
     def transform_doc_comments(text):
         """

--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -143,7 +143,8 @@ class DotNetSphinxMapper(SphinxMapperBase):
         except KeyError:
             self.app.warn('Unknown type: %s' % data)
         else:
-            obj = cls(data, jinja_env=self.jinja_env, options=options)
+            obj = cls(data, jinja_env=self.jinja_env, options=options,
+                      url_root=self.url_root)
 
             # Append child objects
             # TODO this should recurse in the case we're getting back more
@@ -357,8 +358,12 @@ class DotNetPythonMapper(PythonMapperBase):
 
     @property
     def include_path(self):
-        """Return 'absolute' path without regarding OS path separator"""
-        parts = ['/autoapi']
+        """Return 'absolute' path without regarding OS path separator
+
+        This is used in ``toctree`` directives, as Sphinx always expects Unix
+        path separators
+        """
+        parts = [self.url_root]
         parts.extend(self.pathname.split(os.path.sep))
         parts.append('index')
         return '/'.join(parts)

--- a/autoapi/settings.py
+++ b/autoapi/settings.py
@@ -9,3 +9,5 @@ import os
 
 SITE_ROOT = os.path.dirname(os.path.realpath(__file__))
 TEMPLATE_DIR = os.path.join(SITE_ROOT, 'templates')
+
+URL_ROOT = '/autoapi'

--- a/autoapi/settings.py
+++ b/autoapi/settings.py
@@ -10,4 +10,4 @@ import os
 SITE_ROOT = os.path.dirname(os.path.realpath(__file__))
 TEMPLATE_DIR = os.path.join(SITE_ROOT, 'templates')
 
-URL_ROOT = '/autoapi'
+API_ROOT = 'autoapi'

--- a/autoapi/templates/dotnet/base_list.rst
+++ b/autoapi/templates/dotnet/base_list.rst
@@ -15,7 +15,7 @@
 
    {% for item in obj.children|sort %}
    {% if item.type != 'namespace' %}
-   {{ item.abs_path }}
+   {{ item.include_path }}
    {% endif %}
    {% endfor %}
 
@@ -30,7 +30,7 @@
 
    {% for item in obj.references|sort %}
    {% if item.type != 'namespace' %}
-   {{ item.abs_path }}
+   {{ item.include_path }}
    {% endif %}
    {% endfor %}
 

--- a/autoapi/templates/dotnet/base_list.rst
+++ b/autoapi/templates/dotnet/base_list.rst
@@ -15,7 +15,7 @@
 
    {% for item in obj.children|sort %}
    {% if item.type != 'namespace' %}
-   /autoapi/{{ item.pathname }}/index
+   {{ item.abs_path }}
    {% endif %}
    {% endfor %}
 
@@ -30,7 +30,7 @@
 
    {% for item in obj.references|sort %}
    {% if item.type != 'namespace' %}
-   /autoapi/{{ item.pathname }}/index
+   {{ item.abs_path }}
    {% endif %}
    {% endfor %}
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -55,7 +55,7 @@ Customization Options
 
 	Default: ``autoapi``
 
-	Directory to output the AutoAPI files into
+	Relative path to output the AutoAPI files into
 
 Debugging Options
 -----------------

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -11,7 +11,7 @@ from autoapi.mappers import dotnet
 from autoapi.settings import TEMPLATE_DIR
 
 
-class DotNetTests(unittest.TestCase):
+class DotNetObjectTests(unittest.TestCase):
 
     def test_type(self):
         '''Test types of some of the objects'''
@@ -128,3 +128,10 @@ class DotNetTests(unittest.TestCase):
             },
             jinja_env=jinja_env)
         self.assertIn('* :dn:cls:`Foo.Baz\\`1`\n', cls.render())
+
+    def test_include_path(self):
+        """Include path"""
+        cls = dotnet.DotNetClass({'id': 'Foo.Bar.Widget'})
+        self.assertEqual(cls.include_path, '/autoapi/Foo/Bar/Widget/index')
+        cls = dotnet.DotNetClass({'id': 'Foo.Bar.Widget'}, url_root='/autofoo')
+        self.assertEqual(cls.include_path, '/autofoo/Foo/Bar/Widget/index')


### PR DESCRIPTION
Replaces OS path separators with unix style separators, since that's what
Sphinx is expecting in toctree directives.

Fixes #37