### PR TITLE
Fix up generated path separator when on Windows

### DIFF
--- a/autoapi/mappers/base.py
+++ b/autoapi/mappers/base.py
@@ -122,7 +122,7 @@ class PythonMapperBase(object):
         slug = unidecode.unidecode(slug)
         slug = slug.replace('-', '')
         slug = re.sub(r'[^\w\.]+', '-', slug).strip('-')
-        return os.path.join(*slug.split('.'))
+        return os.path.join(*slug.split('.')).replace('\\', '/')
 
     @property
     def include_path(self):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -104,17 +104,17 @@ class DotNetObjectTests(unittest.TestCase):
     def test_filename(self):
         '''Object file name'''
         cls = dotnet.DotNetClass({'id': 'Foo.Bar.Widget'})
-        self.assertEqual(cls.pathname, os.path.join('Foo', 'Bar', 'Widget'))
+        self.assertEqual(cls.pathname, os.path.join('Foo', 'Bar', 'Widget')..replace('\\', '/'))
         cls = dotnet.DotNetClass({'id': 'Foo.Bar.Widget<T>'})
-        self.assertEqual(cls.pathname, os.path.join('Foo', 'Bar', 'Widget-T'))
+        self.assertEqual(cls.pathname, os.path.join('Foo', 'Bar', 'Widget-T').replace('\\', '/'))
         cls = dotnet.DotNetClass({'id': 'Foo.Bar.Widget<T>(TFoo)'})
-        self.assertEqual(cls.pathname, os.path.join('Foo', 'Bar', 'Widget-T'))
+        self.assertEqual(cls.pathname, os.path.join('Foo', 'Bar', 'Widget-T').replace('\\', '/'))
         cls = dotnet.DotNetClass({'id': 'Foo.Foo-Bar.Widget<T>(TFoo)'})
-        self.assertEqual(cls.pathname, os.path.join('Foo', 'FooBar', 'Widget-T'))
+        self.assertEqual(cls.pathname, os.path.join('Foo', 'FooBar', 'Widget-T').replace('\\', '/'))
         cls = dotnet.DotNetClass({'id': u'Foo.Bär'})
-        self.assertEqual(cls.pathname, os.path.join('Foo', 'Bar'))
+        self.assertEqual(cls.pathname, os.path.join('Foo', 'Bar').replace('\\', '/'))
         cls = dotnet.DotNetClass({'id': u'Ащщ.юИфк'})
-        self.assertEqual(cls.pathname, os.path.join('Ashchshch', 'iuIfk'))
+        self.assertEqual(cls.pathname, os.path.join('Ashchshch', 'iuIfk').replace('\\', '/'))
 
     def test_rendered_class_escaping(self):
         """Rendered class escaping"""

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -104,7 +104,7 @@ class DotNetObjectTests(unittest.TestCase):
     def test_filename(self):
         '''Object file name'''
         cls = dotnet.DotNetClass({'id': 'Foo.Bar.Widget'})
-        self.assertEqual(cls.pathname, os.path.join('Foo', 'Bar', 'Widget')..replace('\\', '/'))
+        self.assertEqual(cls.pathname, os.path.join('Foo', 'Bar', 'Widget').replace('\\', '/'))
         cls = dotnet.DotNetClass({'id': 'Foo.Bar.Widget<T>'})
         self.assertEqual(cls.pathname, os.path.join('Foo', 'Bar', 'Widget-T').replace('\\', '/'))
         cls = dotnet.DotNetClass({'id': 'Foo.Bar.Widget<T>(TFoo)'})


### PR DESCRIPTION
On windows os.path.join will generate a path with forward slashes, which messes up the generated toctree paths. 

This little hack will fix up the path separators to be forward slashes. There's probably a more correct way to do this, but this seems to works for most cases.