### PR TITLE
.NET template output breaks definition lists on listing pages

### DIFF
--- a/autoapi/templates/dotnet/base_list.rst
+++ b/autoapi/templates/dotnet/base_list.rst
@@ -49,6 +49,8 @@
 {% macro render() %}{{ obj_item.summary }}{% endmacro %}
 
     {{ obj_item.type }} :dn:{{ obj_item.ref_directive }}:`{{ obj_item.ref_name }}`
+        .. object: type={{ obj_item.type }} name={{ obj_item.ref_name }}
+
         {{ render()|indent(8) }}
 
 {%- endfor %}


### PR DESCRIPTION
See rtfd/sphinxcontrib-dotnetdomain#45 for more info.

![screen shot 2016-01-12 at 4 04 13 pm](https://cloud.githubusercontent.com/assets/1140183/12281277/9f2e9080-b949-11e5-9cd8-93c99486603d.png)
