### PR TITLE
Add resolution to spec identifiers using docfx references

### DIFF
--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -112,8 +112,10 @@ class DotNetSphinxMapper(SphinxMapperBase):
     def map(self, options=None, **kwargs):
         '''Trigger find of serialized sources and build objects'''
         for path, data in self.paths.items():
+            references = data['references']
             for item in data['items']:
-                for obj in self.create_class(item, options):
+                for obj in self.create_class(item, options,
+                                             references=references):
                     self.add_object(obj)
 
         self.organize_objects()
@@ -144,7 +146,7 @@ class DotNetSphinxMapper(SphinxMapperBase):
             self.app.warn('Unknown type: %s' % data)
         else:
             obj = cls(data, jinja_env=self.jinja_env, options=options,
-                      url_root=self.url_root)
+                      url_root=self.url_root, **kwargs)
 
             # Append child objects
             # TODO this should recurse in the case we're getting back more
@@ -235,11 +237,18 @@ class DotNetSphinxMapper(SphinxMapperBase):
 
 class DotNetPythonMapper(PythonMapperBase):
 
-    '''Base .NET object representation'''
+    """Base .NET object representation
+
+    :param references: object reference list from docfx
+    :type references: list of dict objects
+    """
 
     language = 'dotnet'
 
     def __init__(self, obj, **kwargs):
+        self.references = dict((obj.get('uid'), obj)
+                               for obj in kwargs.pop('references', [])
+                               if 'uid' in obj)
         super(DotNetPythonMapper, self).__init__(obj, **kwargs)
 
         # Always exist
@@ -271,13 +280,15 @@ class DotNetPythonMapper(PythonMapperBase):
                 if 'id' in param:
                     self.parameters.append({
                         'name': param.get('id'),
-                        'type': param.get('type'),
+                        'type': self.resolve_spec_identifier(param.get('type')),
                         'desc': self.transform_doc_comments(
                             param.get('description', ''))
                     })
 
             self.returns = {}
-            self.returns['type'] = syntax.get('return', {}).get('type')
+            self.returns['type'] = self.resolve_spec_identifier(
+                syntax.get('return', {}).get('type')
+            )
             self.returns['description'] = self.transform_doc_comments(
                 syntax.get('return', {}).get('description'))
 
@@ -418,6 +429,15 @@ class DotNetPythonMapper(PythonMapperBase):
         except TypeError:
             pass
         return text
+
+    def resolve_spec_identifier(self, obj_name):
+        """Find reference name based on spec identifier
+
+        Spec identifiers are used in parameter and return type definitions, but
+        should be a user-friendly version instead. Use docfx ``references``
+        lookup mapping for resolution.
+        """
+        return self.references.get(obj_name, {}).get('fullName', obj_name)
 
 
 class DotNetNamespace(DotNetPythonMapper):

--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -466,7 +466,7 @@ class DotNetPythonMapper(PythonMapperBase):
                 parts.append('{fullName}<{uid}>'.format(**part))
             elif 'uid' in part:
                 parts.append(part['uid'])
-            elif 'fullName':
+            elif 'fullName' in part:
                 parts.append(part['fullName'])
         if parts:
             resolved = ''.join(parts)

--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -112,7 +112,7 @@ class DotNetSphinxMapper(SphinxMapperBase):
     def map(self, options=None, **kwargs):
         '''Trigger find of serialized sources and build objects'''
         for path, data in self.paths.items():
-            references = data['references']
+            references = data.get('references', [])
             for item in data['items']:
                 for obj in self.create_class(item, options,
                                              references=references):

--- a/autoapi/templates/dotnet/base_detail.rst
+++ b/autoapi/templates/dotnet/base_detail.rst
@@ -60,6 +60,9 @@ GitHub
 
 {% block content %}
 
+.. dn:{{ obj.ref_type }}:: {{ obj.definition }}
+    :hidden:
+
 .. dn:{{ obj.ref_type }}:: {{ obj.name }}
 
 {%- for item_type in obj.item_map.keys() %}

--- a/autoapi/templates/dotnet/base_embed.rst
+++ b/autoapi/templates/dotnet/base_embed.rst
@@ -7,7 +7,7 @@
     {% endif %}
 
     {%- for param in obj.parameters %}
-    
+
     {% if param.desc %}
     :param {{ param.name }}: {{ param.desc|indent(8) }}
     {% endif %}


### PR DESCRIPTION
This uses the docfx output references to resolve the spec identifier to a human
friendly name. If the reference is a nested reference, build up output for parameter and return defined types, which the domain will deconstruct and link separately. This also fixes `paramref` xml parsing and display.

The parameter field output uses a special syntax that the domain will parse out, from rtfd/sphinx-contribdotnetdomain#54. The output looks like:

```
    :type foo: Foo<Foo`1>{Bar<Bar`1>{TUser}}
```

This provides two references that will resolve, both with aliased targets, and one, `TUser` which will ultimately fail resolution

Example:
![screen shot 2016-03-04 at 10 44 01 am](https://cloud.githubusercontent.com/assets/1140183/13536669/0c309564-e1f6-11e5-99d2-5c7e2ad8dc98.png)

This work also adds hidden obj definitions so that both reference syntaxes are linkable:

```
:dn:cls:`Foo<TBar>`
:dn:cls:`Foo\`1`
```

Fixes #58
Requires rtfd/sphinxcontrib-dotnetdomain#54

Work left:
- [x] Resolve each identifier in strings like `Foo<Bar<Task>>` -- it might make sense to do this as a more general update to the dotnet domain reference handling.