### PR TITLE
Handle string input for api dir

### DIFF
--- a/autoapi/extension.py
+++ b/autoapi/extension.py
@@ -27,7 +27,10 @@ def run_autoapi(app):
 
     # Make sure the paths are full
     normalized_dirs = []
-    for path in app.config.autoapi_dirs:
+    autoapi_dirs = app.config.autoapi_dirs
+    if isinstance(autoapi_dirs, basestring):
+        autoapi_dirs = [autoapi_dirs]
+    for path in autoapi_dirs:
         if os.path.isabs(path):
             normalized_dirs.append(path)
         else:


### PR DESCRIPTION
This was iterating over the settings assuming it was a list. We handle this as a
list in some instances, and recommend using a string in others. Just handle
both.

Refs #53 