### PR TITLE
Clean up .NET detail page, add assemblies list

### DIFF
--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -265,6 +265,7 @@ class DotNetPythonMapper(PythonMapperBase):
         self.children = []
         self.item_map = defaultdict(list)
         self.inheritance = []
+        self.assemblies = obj.get('assemblies', [])
 
         # Syntax example and parameter list
         syntax = obj.get('syntax', None)

--- a/autoapi/templates/dotnet/base_detail.rst
+++ b/autoapi/templates/dotnet/base_detail.rst
@@ -5,21 +5,29 @@
 
 {% endblock %}
 
-.. contents:: 
-   :local:
-
 {% block summary %}
-
-{%- if obj.summary %}
-
-Summary
--------
+  {%- if obj.summary %}
 
 {{ obj.summary }}
 
+  {%- endif %}
+{% endblock %}
+
+{%- if obj.namespace %}
+Namespace
+    :dn:ns:`{{ obj.namespace }}`
+{%- endif %}
+{%- if obj.assemblies %}
+Assemblies
+  {%- for assembly in obj.assemblies %}
+    * {{ assembly }}
+  {%- endfor %}
 {%- endif %}
 
-{% endblock %}
+----
+
+.. contents::
+   :local:
 
 {% block inheritance %}
 
@@ -50,12 +58,6 @@ Syntax
 {% endif %}
 
 {% endblock %}
-
-GitHub
-------
-
-`View on GitHub <{{ obj.edit_link }}>`_
-
 
 
 {% block content %}


### PR DESCRIPTION
The .NET detail page was slightly messy, this cleans up and settles on some UX
there:

* Don't use an explicit header for summary, move it up under the object heading
* Drop redundant (and broken) github edit link on page, we need to fix the
  github header link instead.
* Add pattern for displaying read only fields in definition list
* Adds namespace + assemblies listing to detail page

Refs #60

![screen shot 2016-05-01 at 7 57 14 pm](https://cloud.githubusercontent.com/assets/1140183/14946470/98484f1a-0fd7-11e6-80f6-b211ddd29f4f.png)