### PR TITLE
Make docfx great again!

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,8 +48,8 @@ Basic Workflow
 Sphinx AutoAPI has the following structure:
 
 * Configure directory to look for source files
-* Generate JSON from those source files, using language-specific tooling
-* Map the JSON into standard AutoAPI Python objects
+* Serialize those source files, using language-specific tooling
+* Map the serialized data into standard AutoAPI Python objects
 * Generate RST through Jinja2 templates from those Python objects
 
 This basic framework should be easy to implement in your language of choice.
@@ -58,37 +58,93 @@ All you need to do is be able to generate a JSON structure that includes your AP
 Install
 -------
 
-
 First you need to install autoapi:
 
 .. code:: bash
-	
-	pip install sphinx-autoapi
+
+    pip install sphinx-autoapi
 
 Then add it to your Sphinx project's ``conf.py``:
 
 .. code:: python
 
-	extensions = ['autoapi.extension']
+    extensions = ['autoapi.extension']
 
-        # Document Python Code
-	autoapi_type = 'python'
-	autoapi_dir = 'path/to/python/files'
+    # Document Python Code
+    autoapi_type = 'python'
+    autoapi_dirs = ['path/to/python/files', 'path/to/more/python/files']
 
-        # Or, Document Go Code
-	autoapi_type = 'go'
-	autoapi_dir = 'path/to/go/files'
+    # Or, Document Go Code
+    autoapi_type = 'go'
+    autoapi_dirs = 'path/to/go/files'
 
-AutoAPI will automatically add itself to the last TOCTree in your top-level ``index.rst``.
+AutoAPI will automatically add itself to the last TOCTree in your top-level
+``index.rst``.
 
-This is needed because we will be outputting rst files into the ``autoapi`` directory.
-This adds it into the global TOCTree for your project,
-so that it appears in the menus.
+This is needed because we will be outputting rst files into the ``autoapi``
+directory.  This adds it into the global TOCTree for your project, so that it
+appears in the menus.
 
-We hope to be able to dynamically add items into the TOCTree, and remove this step.
-However, it is currently required.
+We hope to be able to dynamically add items into the TOCTree, and remove this
+step.  However, it is currently required.
 
 See all available configuration options in :doc:`config`.
+
+Setup
+-----
+
+.NET
+~~~~
+
+The .NET mapping utilizes the tool `docfx`_. To install ``docfx``, first
+you'll need to `install a .NET runtime on your system <ASP.NET Installation>`_.
+
+The docfx tool can be installed with::
+
+    dnu commands install docfx
+
+By default, ``docfx`` will output metadata files into the ``_api`` path. You
+can configure which path to output files into using a ``docfx.json`` file in
+your project's repository. Here's an example from the ASP.NET docs:
+
+.. code:: json
+
+    {
+      "metadata": [{
+        "src": [{
+          "files": [
+            "aspnet/identity/src/\*\*/project.json"
+          ],
+          "exclude": [
+            "aspnet/testing/src/Microsoft.AspNet.Testing/\*"
+          ]
+        }],
+        "dest": "docs/_api",
+        "force": "true",
+        "raw": "true"
+      }]
+    }
+
+.. note::
+    The ``dest`` configuration option is required to output to the ``docs/``
+    path, where autoapi knows to search for these files.
+
+With a working ``docfx`` toolchain, you can now add the configuration options
+to enable the .NET autoapi mapper. In your ``conf.py``:
+
+.. code:: python
+
+    extensions = ['autoapi.extension']
+    autoapi_type = 'dotnet'
+    autoapi_dirs = ['..']
+
+This configuration, which assumes your ``conf.py`` is in a ``docs/`` path,
+will use your parent path to search for files to pass to ``docfx``. If you
+have a ``docfx.json`` file present, and did not specify a custom pattern for
+finding files, ``docfx.json`` will be used first.
+
+.. _`docfx`: https://github.com/dotnet/docfx
+.. _`ASP.NET Installation`: http://docs.asp.net/en/latest/getting-started/index.html
 
 Customize
 ---------
@@ -106,7 +162,7 @@ Currently Implemented
 ---------------------
 
 * Python (2 only -- Epydoc doesn't support Python 3)
-* .Net
+* .NET
 * Go
 * Javascript
 

--- a/README.rst
+++ b/README.rst
@@ -104,24 +104,17 @@ The docfx tool can be installed with::
     dnu commands install docfx
 
 By default, ``docfx`` will output metadata files into the ``_api`` path. You
-can configure which path to output files into using a ``docfx.json`` file in
-your project's repository. Here's an example from the ASP.NET docs:
+can configure which path to output files into by setting the path in your
+`docfx configuration file`_ in your project's repository. For example:
 
 .. code:: json
 
     {
+      ...
       "metadata": [{
-        "src": [{
-          "files": [
-            "aspnet/identity/src/\*\*/project.json"
-          ],
-          "exclude": [
-            "aspnet/testing/src/Microsoft.AspNet.Testing/\*"
-          ]
-        }],
+        ...
         "dest": "docs/_api",
-        "force": "true",
-        "raw": "true"
+        ...
       }]
     }
 
@@ -138,13 +131,18 @@ to enable the .NET autoapi mapper. In your ``conf.py``:
     autoapi_type = 'dotnet'
     autoapi_dirs = ['..']
 
-This configuration, which assumes your ``conf.py`` is in a ``docs/`` path,
-will use your parent path to search for files to pass to ``docfx``. If you
-have a ``docfx.json`` file present, and did not specify a custom pattern for
-finding files, ``docfx.json`` will be used first.
+This configuration assumes your ``conf.py`` is in a ``docs/`` path, and will use
+your parent path ('..') to search for files to pass to ``docfx``. Unless you
+specify a custom pattern, using the ``autoapi_patterns`` option,
+``sphinx-autoapi`` will assume a list of file names to search.
+
+First, a ``docfx.json`` file will be searched for. If this file exists, it will
+be used, regardless of whether you have other file patterns listed. Otherwise,
+any file matching ``['project.json', 'csproj', 'vsproj']`` will be searched for.
 
 .. _`docfx`: https://github.com/dotnet/docfx
 .. _`ASP.NET Installation`: http://docs.asp.net/en/latest/getting-started/index.html
+.. _`docfx configuration file`: https://dotnet.github.io/docfx/tutorial/docfx.exe_user_manual.html#3-docfx-json-format
 
 Customize
 ---------

--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -49,7 +49,7 @@ class DotNetSphinxMapper(SphinxMapperBase):
     '''Auto API domain handler for .NET
 
     Searches for YAML files, and soon to be JSON files as well, for auto API
-    sources. If not pattern configuration was explicitly specified, then default
+    sources. If no pattern configuration was explicitly specified, then default
     to looking up a ``docfx.json`` file.
 
     :param app: Sphinx application passed in as part of the extension
@@ -62,10 +62,10 @@ class DotNetSphinxMapper(SphinxMapperBase):
     def load(self, patterns, dirs, ignore=None, **kwargs):
         '''Load objects from the filesystem into the ``paths`` dictionary.
 
-        If a patterns setting was not specified, look for a ``docfx.json`` file
-        by default.  A ``docfx.json`` should be treated as the canonical source
-        before the default patterns.  Fallback to default pattern matches if no
-        ``docfx.json`` files are found.
+        If the setting ``autoapi_patterns`` was not specified, look for a
+        ``docfx.json`` file by default.  A ``docfx.json`` should be treated as
+        the canonical source before the default patterns.  Fallback to default
+        pattern matches if no ``docfx.json`` files are found.
         '''
         raise_error = kwargs.get('raise_error', True)
         all_files = set()

--- a/autoapi/templates/dotnet/operator.rst
+++ b/autoapi/templates/dotnet/operator.rst
@@ -1,0 +1,1 @@
+{% extends "dotnet/base_embed.rst" %}

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -12,8 +12,12 @@ class DotNetSphinxMapperTests(unittest.TestCase):
     def setUp(self):
         '''Test setup'''
         class _config(object):
-            autoapi_dirs = ['/tmp/autoapi/tmp']
-            autoapi_root = '/tmp/autoapi/root'
+            def __getattr__(self, key):
+                attrs = {
+                    'autoapi_dirs': ['/tmp/autoapi/tmp'],
+                    'autoapi_root': '/tmp/autoapi/root',
+                }
+                return attrs.get(key, None)
 
         class _application(object):
             config = _config()


### PR DESCRIPTION
This updates some small outdated pieces with docfx integration:

* Support docfx.json first, if no patterns were explicitly specified
* Refactor output path, use new _api path
* Add missing operator type to .net parsing and template output
* Fix indent issue with code samples
* Add docs on how to actually use docfx + autoapi

Fixes #45
Fixes #46
Fixes #48