### PR TITLE
Revert basestring -> str in check for autoapi_dirs

### DIFF
--- a/autoapi/extension.py
+++ b/autoapi/extension.py
@@ -28,7 +28,7 @@ def run_autoapi(app):
     # Make sure the paths are full
     normalized_dirs = []
     autoapi_dirs = app.config.autoapi_dirs
-    if isinstance(autoapi_dirs, basestring):
+    if isinstance(autoapi_dirs, str):
         autoapi_dirs = [autoapi_dirs]
     for path in autoapi_dirs:
         if os.path.isabs(path):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,lint,docs
+envlist = py27,py35,lint,docs
 
 [testenv]
 setenv =
@@ -9,7 +9,9 @@ commands =
     py.test {posargs}
 
 [testenv:docs]
-deps = {[testenv]deps}
+deps =
+    sphinx_rtd_theme
+    {[testenv]deps}
 changedir = {toxinidir}/docs
 commands =
     sphinx-build -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html


### PR DESCRIPTION
Not sure we need to be concerned about byte strings here either way.

Fixes #74