### PR TITLE
Fix for Sphinx 1.5

### DIFF
--- a/autoapi/extension.py
+++ b/autoapi/extension.py
@@ -134,7 +134,7 @@ def doctree_read(app, doctree):
             app.info(bold('[AutoAPI] ') +
                      darkgreen('Adding AutoAPI TOCTree [%s] to index.rst' % toc_entry)
                      )
-            app.env.build_toc_from(app.env.docname, doctree)
+            app.env.toctree.process_doc(app.env.docname, doctree)
 
 
 def setup(app):


### PR DESCRIPTION
`build_toc_from` has been moved to `Toctree.process_doc` in Sphinx 1.5