### PR TITLE
Start altering the pydocstyle AST parser for our needs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,20 @@
 language: python
 python:
- - 2.7
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
 sudo: false
-env:
- - TOX_ENV=py27
- - TOX_ENV=docs
- - TOX_ENV=lint
+matrix:
+  include:
+    - python: 2.7
+      script: tox -e docs
+    - python: 2.7
+      script: tox -e lint
 install:
- - pip install tox
+  - pip install tox-travis
 script:
- - tox -e $TOX_ENV
+  - tox
 notifications:
   slack:
     rooms:

--- a/autoapi/mappers/python.py
+++ b/autoapi/mappers/python.py
@@ -381,7 +381,7 @@ class ParserExtra(parser.Parser):
                 # TODO Skip these for now. In the future, this name should be
                 # converted to an object that will be resolved after we've
                 # parsed at a later stage in the mapping process.
-                #all_content.append(name)
+                # all_content.append(name)
             if self.current.kind == tk.OP and self.current.value == '+':
                 self.stream.move()
             else:

--- a/tests/test_python_parser.py
+++ b/tests/test_python_parser.py
@@ -66,3 +66,18 @@ class PythonParserTests(unittest.TestCase):
         ]
         """
         self.assertEqual(self.parse(source).all, ['foo', 'bar'])
+
+    def test_parses_all_generator(self):
+        source = """
+        __all__ = [x for x in dir(token) if x[0] != '_'] + ['foo', 'bar']
+        """
+        out = self.parse(source)
+        self.assertEqual(self.parse(source).all, ['foo', 'bar'])
+
+    def test_parses_name(self):
+        source = "foo.bar"
+        self.assertEqual(self.parse(source).children, [])
+
+    def test_parses_list(self):
+        source = "__all__ = [[1, 2], [3, 4]]"
+        self.assertEqual(self.parse(source).all, [[1, 2], [3, 4]])

--- a/tests/test_python_parser.py
+++ b/tests/test_python_parser.py
@@ -1,0 +1,68 @@
+# coding=utf8
+
+"""Test Python parser"""
+
+import sys
+import unittest
+from textwrap import dedent
+
+from autoapi.mappers.python import ParserExtra
+
+if sys.version_info < (3, 0):
+    from StringIO import StringIO
+else:
+    from io import StringIO
+
+
+class PythonParserTests(unittest.TestCase):
+
+    def parse(self, source):
+        in_h = StringIO(dedent(source))
+        return ParserExtra()(in_h, '/dev/null')
+
+    def test_parses_basic_file(self):
+        source = """
+        def foo(bar):
+            pass
+        """
+        self.assertIsNone(self.parse(source).all)
+
+    def test_parses_all(self):
+        source = """
+        __all__ = ['Foo', 5.0]
+        """
+        self.assertEqual(self.parse(source).all, ['Foo', 5.0])
+
+    def test_parses_all_with_list_addition(self):
+        source = """
+        __all__ = ['Foo'] + []
+        """
+        self.assertEqual(self.parse(source).all, ['Foo'])
+
+    def test_parses_all_with_name_addtion(self):
+        source = """
+        __all__ = ['Foo'] + bar.__all__
+        """
+        self.assertEqual(self.parse(source).all, ['Foo'])
+
+    def test_parses_all_with_multiple_name_addtions(self):
+        source = """
+        __all__ = foo + bar
+        __all__ += boop
+        __all__ += ['foo']
+        """
+        self.assertEqual(self.parse(source).all, ['foo'])
+        source = """
+        __all__ = ['foo']
+        __all__ = foo
+        """
+        self.assertEqual(self.parse(source).all, [])
+
+    def test_parses_all_multiline(self):
+        source = """
+        __all__ = [
+            'foo',
+            'bar',
+        ]
+        """
+        self.assertEqual(self.parse(source).all, ['foo', 'bar'])

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
     py{27,34,35}-sphinx{13,14,15}
-    py27-lint
-    py27-docs
+    lint
+    docs
 
 [testenv]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
-envlist = py27,py35,lint,docs
+envlist =
+    py{27,34,35}-sphinx{13,14,15}
+    py27-lint
+    py27-docs
 
 [testenv]
 setenv =
@@ -7,11 +10,14 @@ setenv =
 deps = -r{toxinidir}/requirements.txt
     pytest
     mock
+    sphinx14: Sphinx<1.5
+    sphinx15: Sphinx<1.6
 commands =
     py.test {posargs}
 
 [testenv:docs]
 deps =
+    Sphinx==1.5
     sphinx_rtd_theme
     {[testenv]deps}
 changedir = {toxinidir}/docs

--- a/tox.ini
+++ b/tox.ini
@@ -19,14 +19,12 @@ commands =
 deps =
     Sphinx==1.5
     sphinx_rtd_theme
-    {[testenv]deps}
 changedir = {toxinidir}/docs
 commands =
     sphinx-build -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
 
 [testenv:lint]
 deps =
-    {[testenv]deps}
     prospector
 commands =
     prospector \


### PR DESCRIPTION
This forks some of the pydocstyle AST parser into out mapper. Eventually, some
of the other operations such as parsing arguments and performing full name
lookup can be moved in as well. For now, this is not doing any extra assignment
tracking/etc, several of these operations will just throw this information out.

Refs #99