### PR TITLE
Allow for toplevel module as Sphinx extension

### DIFF
--- a/autoapi/__init__.py
+++ b/autoapi/__init__.py
@@ -1,3 +1,5 @@
 """
-AutoAPI Top-level Comment
+Sphinx AutoAPI
 """
+
+from .extension import setup


### PR DESCRIPTION
Instead of requiring:

    extensions = ['autoapi.extension']

This allows for the toplevel:

    extensions = ['autoapi']

This is more intuitive for users, as extension is an internal concept.