### PR TITLE
Fix for Sphinx 1.6

### DIFF
--- a/autoapi/extension.py
+++ b/autoapi/extension.py
@@ -135,10 +135,6 @@ def doctree_read(app, doctree):
             app.info(bold('[AutoAPI] ') +
                      darkgreen('Adding AutoAPI TOCTree [%s] to index.rst' % toc_entry)
                      )
-            if sphinx.version_info >= (1, 5):
-                app.env.toctree.process_doc(app.env.docname, doctree)
-            else:
-                app.env.build_toc_from(app.env.docname, doctree)
 
 
 def setup(app):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -89,6 +89,15 @@ class PythonTests(LanguageIntegrationTests):
             self.assertFalse(
                 os.path.exists('_build/text/autoapi/method_multiline')
             )
+            index_file = open('_build/text/index.txt').read()
+            self.assertIn(
+                'Sphinx AutoAPI Index',
+                index_file
+            )
+            self.assertIn(
+                'Foo',
+                index_file
+            )
 
 
 class DotNetTests(LanguageIntegrationTests):

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ setenv =
 deps = -r{toxinidir}/requirements.txt
     pytest
     mock
+    sphinx13: Sphinx<1.4
     sphinx14: Sphinx<1.5
     sphinx15: Sphinx<1.6
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35}-sphinx{13,14,15}
+    py{27,34,35}-sphinx{13,14,15,16}
     lint
     docs
 
@@ -13,12 +13,13 @@ deps = -r{toxinidir}/requirements.txt
     sphinx13: Sphinx<1.4
     sphinx14: Sphinx<1.5
     sphinx15: Sphinx<1.6
+    sphinx16: Sphinx<1.7
 commands =
     py.test {posargs}
 
 [testenv:docs]
 deps =
-    Sphinx==1.5
+    Sphinx>=1.6,<=1.7
     sphinx_rtd_theme
 changedir = {toxinidir}/docs
 commands =


### PR DESCRIPTION
This fixes autoapi for Sphinx 1.6. We actually don't need to call `process_doc` at all. `process_doc` edits the doctree just before pickling. Sphinx events are queued so each extension runs it's own `process_doc` before Sphinx starts writing the doctree out.