### PR TITLE
Fixed usage of deprecated status_indicator

### DIFF
--- a/autoapi/mappers/base.py
+++ b/autoapi/mappers/base.py
@@ -5,6 +5,7 @@ from collections import OrderedDict, namedtuple
 
 import unidecode
 from jinja2 import Environment, FileSystemLoader, TemplateNotFound
+import sphinx.util
 from sphinx.util.console import darkgreen, bold
 from sphinx.util.osutil import ensuredir
 from sphinx.util.docstrings import prepare_docstring
@@ -234,7 +235,12 @@ class SphinxMapperBase(object):
 
                         files_to_read.append(filename)
 
-        for _path in self.app.status_iterator(
+        if sphinx.version_info >= (1, 6):
+            status_iterator = sphinx.util.status_iterator
+        else:
+            status_iterator = self.app.status_iterator
+
+        for _path in status_iterator(
                 files_to_read,
                 '[AutoAPI] Reading files... ',
                 darkgreen,


### PR DESCRIPTION
`app.status_indicator` is deprecated in Sphinx 1.6, and is removed for the upcoming 1.7 version. This switches to using `sphinx.utils.status_indicator` instead as recommended by Sphinx (http://www.sphinx-doc.org/en/stable/changes.html#id9).