### PR TITLE
126 unrecognized jsdoc tag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,6 +144,47 @@ any file matching ``['project.json', 'csproj', 'vsproj']`` will be searched for.
 .. _`ASP.NET Installation`: http://docs.asp.net/en/latest/getting-started/index.html
 .. _`docfx configuration file`: https://dotnet.github.io/docfx/tutorial/docfx.exe_user_manual.html#3-docfx-json-format
 
+
+GO
+~~~~
+
+Install go domain extension for sphinx.
+
+.. code:: bash
+  pip install go sphinxcontrib_golangdomain
+
+
+Install the go environment (from https://golang.org/dl/).
+
+Install a git client for your environment (e.g. from https://desktop.github.com/).
+
+Install our godocjson tool (preprocess godoc output to JSON, in a way similar to jsdoc -X).
+
+.. code:: bash
+  go get github.com/rtfd/godocjson
+
+Add go domain in your conf.py.
+
+.. code:: python
+  extensions = [ 'sphinxcontrib.golangdomain',...
+
+Before running building your doc, make sure the godocjson executable is in your path.
+
+Javascript
+~~~~~~~~~~~~~~~~
+
+Requires jsdoc, which in turn requires nodejs to be installed.
+
+Install nodejs on your platform.
+
+Install jsdoc using npm.
+
+.. code:: bash
+  npm install jsdoc -g
+
+Before building your doc, make sure the jsdoc executable is in your path.
+
+
 Customize
 ---------
 

--- a/autoapi/mappers/javascript.py
+++ b/autoapi/mappers/javascript.py
@@ -35,7 +35,7 @@ class JavaScriptSphinxMapper(SphinxMapperBase):
     def map(self, options=None):
         '''Trigger find of serialized sources and build objects'''
         for path, data in self.paths.items():
-            for item in (i for i in data if not u'files' in i):
+            for item in (i for i in data if u'files' not in i):
                 for obj in self.create_class(item, options):
                     obj.jinja_env = self.jinja_env
                     self.add_object(obj)

--- a/autoapi/mappers/javascript.py
+++ b/autoapi/mappers/javascript.py
@@ -35,7 +35,7 @@ class JavaScriptSphinxMapper(SphinxMapperBase):
     def map(self, options=None):
         '''Trigger find of serialized sources and build objects'''
         for path, data in self.paths.items():
-            for item in data:
+            for item in (i for i in data if not u'files' in i):
                 for obj in self.create_class(item, options):
                     obj.jinja_env = self.jinja_env
                     self.add_object(obj)


### PR DESCRIPTION
PR for issue #126.
This is a quick and dirty fix to avoid frustration when using jsdoc versions producing a list of files for a package ("file:"). This attribute is not interpreted yet however, just filtered out.