### PR TITLE
Can control how __init__ docstring is displayed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ _api_
 .eggs
 .ropeproject/
 .cache
+.pytest_cache/

--- a/autoapi/extension.py
+++ b/autoapi/extension.py
@@ -208,6 +208,7 @@ def setup(app):
     app.add_config_value('autoapi_add_api_root_toctree', False, 'html')
     app.add_config_value('autoapi_template_dir', None, 'html')
     app.add_config_value('autoapi_include_summaries', False, 'html')
+    app.add_config_value('autoapi_python_class_content', 'class', 'html')
     app.add_stylesheet('autoapi.css')
     directives.register_directive('autoapi-nested-parse', NestedParse)
     directives.register_directive('autoapisummary', AutoapiSummary)

--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -354,7 +354,7 @@ class DotNetPythonMapper(PythonMapperBase):
                 repo=repo,
                 path=path,
             )
-        except:
+        except Exception:
             return ''
 
     @property

--- a/autoapi/mappers/javascript.py
+++ b/autoapi/mappers/javascript.py
@@ -129,6 +129,7 @@ class JavaScriptAttribute(JavaScriptPythonMapper):
     type = 'attribute'
     ref_directive = 'attr'
 
+
 ALL_CLASSES = [
     JavaScriptFunction,
     JavaScriptClass,

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -63,6 +63,21 @@ Customization Options
 
 	Whether include autosummary directives in generated module documentation.
 
+.. confval:: autoapi_python_class_content
+
+	Default: ``class``
+
+	Which docstring to insert into the content of the class.
+
+	:param class: Use only the class docstring.
+	:param both: Use the concatentation of the class docstring and the
+	``__init__``/``__new__`` docstring.
+	:param init: Use only the ``__init__``/``__new__`` docstring.
+
+	If the class does not have an ``__init__`` or the ``__init__``
+	docstring is empty and the class defines a ``__new__`` with a docstring,
+	the ``__new__`` docstring is used instead of the ``__init__`` docstring.
+
 Debugging Options
 -----------------
 

--- a/tests/pyexample/example/example.py
+++ b/tests/pyexample/example/example.py
@@ -25,6 +25,7 @@ class Foo(object):
             return True
 
     def __init__(self, attr):
+        """Constructor docstring"""
         self.attr = attr
         self.attr2 = attr
         """This is the docstring of an instance attribute.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -172,6 +172,43 @@ class PythonTests(LanguageIntegrationTests):
                 example_file
             )
 
+    def _test_class_content(self, class_content):
+        confoverrides={
+            'autoapi_python_class_content': class_content,
+        }
+
+        with sphinx_build('pyexample', confoverrides=confoverrides):
+            example_path = '_build/text/autoapi/example/index.txt'
+            with io.open(example_path, encoding='utf8') as example_handle:
+                example_file = example_handle.read()
+
+                assert_class = self.assertIn
+                if class_content == 'init':
+                    assert_class = self.assertNotIn
+
+                assert_class(
+                    'Can we parse arguments',
+                    example_file
+                )
+
+                assert_init = self.assertIn
+                if class_content not in ('both', 'init'):
+                    assert_init = self.assertNotIn
+
+                assert_init(
+                    'Constructor docstring',
+                    example_file
+                )
+
+    def test_class_class_content(self):
+        self._test_class_content('class')
+
+    def test_both_class_content(self):
+        self._test_class_content('both')
+
+    def test_init_class_content(self):
+        self._test_class_content('init')
+
 
 class DotNetTests(LanguageIntegrationTests):
 


### PR DESCRIPTION
This adds a new `autoapi_python_class_content` option that works similarly to the [`autoclass_content`](http://www.sphinx-doc.org/en/master/ext/autodoc.html#confval-autoclass_content) option from autodoc.

Closes #107 