### PR TITLE
Include LICENSE in source

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ recursive-include autoapi *.js_t
 recursive-include autoapi *.js
 recursive-include autoapi *.rst
 include *.rst
+include LICENSE.mit


### PR DESCRIPTION
Current the `LICENSE` is not packaged with the source tarball.