### PR TITLE
Fix an issue with function whitespace causing weirdness

### DIFF
--- a/autoapi/templates/python/function.rst
+++ b/autoapi/templates/python/function.rst
@@ -1,6 +1,8 @@
 {% if obj.display %}
 .. function:: {{ obj.short_name }}({{ obj.args }}){% if obj.return_annotation is not none %} -> {{ obj.return_annotation }}{% endif %}
 
+   {# Force Jinja to honor a newline here #}
+   {{''}} 
    {% if obj.docstring %}
    {{ obj.docstring|prepare_docstring|indent(3) }}
    {% endif %}


### PR DESCRIPTION
You can see this live here until it's fixed: https://sphinx-notfound-page.readthedocs.io/en/latest/autoapi/notfound/extension/index.html#notfound.extension.html_collect_pages

This is what it currently looks like:

<img width="650" alt="Screenshot 2019-06-18 13 01 10" src="https://user-images.githubusercontent.com/25510/59715716-54e10d80-91c9-11e9-8603-6f3e052eae5c.png">


It outputs RST that looks like this:

```
.. function:: replace_uris(app, doctree, nodetype, nodeattr)
   Replace ``nodetype`` URIs from ``doctree`` to the proper one.

   Rest of the docstring
```

Where we really want the first space there.

I tried a couple other fixes, but this one was the only one that seemed to work reliably. 